### PR TITLE
chore(bnd) Ensure exit code is propagated to Jenkins from ssh

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,7 +64,9 @@ delpoy_exit_code=$?
 cd ..
 rm -rf HadithHouseApi
 exit $deploy_exit_code
-EOF''')
+EOF
+exit $?
+''')
       }
     }
 
@@ -132,7 +134,9 @@ delpoy_exit_code=$?
 cd ..
 rm -rf HadithHouseApi
 exit $deploy_exit_code
-EOF''')
+EOF
+exit $?
+''')
       }
     }
   }


### PR DESCRIPTION
Ensure that if some partrs of `Jenkinsfile` fail which uses the ssh
command correctly reads the result of the ssh command and
propogate it to Jenkins to prevent silent failures.