### PR TITLE
chore(bnd) Escape commands passed to ssh in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,7 @@ exit $?''')
       }
       steps {
         echo('Arhive HadithHouseApi folder')
-        sh('zip -qr --exclude=venv/* /tmp/archive.zip *')
+        sh('zip -qr --exclude=venv/* --exclude=node_modules/* /tmp/archive.zip *')
 
         echo('Copy the archive to dev.hadithhouse.net for deployment')
         sh('''scp /tmp/archive.zip deployer@dev.hadithhouse.net:/tmp/archive.zip
@@ -52,7 +52,7 @@ rm /tmp/archive.zip
 ''')
 
         echo ('Unzip the archive and start the deployment.')
-        sh('''ssh deployer@dev.hadithhouse.net << EOF
+        sh('''ssh deployer@dev.hadithhouse.net << "EOF"
 cd /tmp
 rm -rf HadithHouseApi
 mkdir HadithHouseApi
@@ -115,14 +115,14 @@ exit $?''')
       }
       steps {
         echo('Arhive HadithHouseApi folder')
-        sh('zip -qr --exclude=venv/* /tmp/archive.zip *')
+        sh('zip -qr --exclude=venv/* --exclude=node_modules/* /tmp/archive.zip *')
 
         echo('Copy the archive to www.hadithhouse.net for deployment')
         sh('''scp /tmp/archive.zip deployer@www.hadithhouse.net:/tmp/archive.zip
 rm /tmp/archive.zip''')
 
         echo ('Unzip the archive and start the deployment.')
-        sh('''ssh deployer@www.hadithhouse.net << EOF
+        sh('''ssh deployer@www.hadithhouse.net << "EOF"
 cd /tmp
 rm -rf HadithHouseApi
 mkdir HadithHouseApi

--- a/scripts/base.sh
+++ b/scripts/base.sh
@@ -15,12 +15,12 @@ on_error() {
   local message="$2"
   local code="${3:-1}"
   if [[ -n "${message}" ]] ; then
-    log_error "build.sh experienced an error on line ${line_lo}: ${message}; exiting with status ${code}"
+    log_error "Script experienced an error on line ${line_lo}: ${message}; exiting with status ${code}"
   else
-    log_error "build.sh experienced an error on line ${line_lo}; exiting with status ${code}"
+    log_error "Script experienced an error on line ${line_lo}; exiting with status ${code}"
   fi
 
-  exit 1
+  exit ${code}
 }
 
 # Stops the execution of the script if any command, including pipes, fail.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -47,5 +47,5 @@ python manage.py collectstatic --noinput
 log "Running tests..."
 python manage.py test
 
-log "Deactivate Python's virtual environment and delete it..."
+log "Deactivate Python's virtual environment..."
 deactivate


### PR DESCRIPTION
The `$?` in the command block passed to the web server in the deployment
section  of Jenkinsfile is being interpolated before it is sent to the server.
I escaped the string so it is not interpolated.